### PR TITLE
[back] #55 get tag filter function

### DIFF
--- a/back/src/models/project/project.model.ts
+++ b/back/src/models/project/project.model.ts
@@ -1,4 +1,5 @@
-import { Table, Column, AllowNull, Model, DataType, HasMany } from "sequelize-typescript";
+import { Table, Column, Model, DataType, ForeignKey, HasMany } from "sequelize-typescript";
+import { Projecttag } from "./projecttag.model";
 
 @Table
 export class Project extends Model {
@@ -17,7 +18,6 @@ export class Project extends Model {
   @Column(DataType.INTEGER)
   like!: number;
 
-  // @AllowNull
-  // @Column(DataType.ENUM('null'))
-  // tag!: string[];
+  @HasMany(() => Projecttag)
+  projecttag!: Projecttag[];
 }

--- a/back/src/models/project/projecttag.model.ts
+++ b/back/src/models/project/projecttag.model.ts
@@ -1,0 +1,20 @@
+import { Table, Column, Model, ForeignKey, BelongsTo } from "sequelize-typescript";
+import { Project } from "./project.model";
+import { Tag } from "./tag.model";
+
+@Table
+export class Projecttag extends Model {
+    @ForeignKey(() => Project)
+    @Column
+    projectId!: number
+
+    @ForeignKey(() => Tag)
+    @Column
+    tagId!: number
+
+    @BelongsTo(() => Project)
+    project!: Project;
+
+    @BelongsTo(() => Tag)
+    tag!: Tag;
+}

--- a/back/src/models/project/tag.model.ts
+++ b/back/src/models/project/tag.model.ts
@@ -1,0 +1,11 @@
+import { Table, Column, HasMany, Model, DataType, ForeignKey } from "sequelize-typescript";
+import { Projecttag } from "./projecttag.model";
+
+@Table
+export class Tag extends Model {
+  @Column(DataType.STRING(20))
+  tagTitle!: string;
+
+  @HasMany(() => Projecttag)
+  projecttag!: Projecttag[];
+}

--- a/back/src/routes/project/project.controller.ts
+++ b/back/src/routes/project/project.controller.ts
@@ -3,7 +3,7 @@ import * as projectService from "./project.service";
 
 const router: express.Router = express.Router();
 
-router.get("/list", (request: Request, response: Response) => {
+router.get("/", (request: Request, response: Response) => {
   projectService.getList(request, response);
 });
 

--- a/back/src/routes/project/project.service.ts
+++ b/back/src/routes/project/project.service.ts
@@ -1,64 +1,61 @@
 import express, { Request, Response } from "express";
 import { Project } from "../../models/project/project.model";
+import { Tag } from "../../models/project/tag.model";
+import { Projecttag } from "../../models/project/projecttag.model";
 
 const app = express();
 app.set('query parser', 'extended');
 
-export const getList = async (request: Request, response: Response) => {
+const pagination = async (request: Request, response: Response, state: string) => {
+    const { page, pageSize, tag } = request.query;
     let offset: number;
     let limit: number;
     let project;
-    if (request.query === null)
+    if (page !== undefined && pageSize !== undefined) {
+        limit = Number(pageSize);
+        offset = (Number(page) - 1) * limit;
+        project = await Project.findAll({
+            include: {
+                model: Projecttag,
+                include: [{ model: Tag, where: { tagTitle: tag }, required: true }],
+                required: true
+            },
+            where: { state: state },
+            offset: offset,
+            limit: limit
+        });
+    } else if (page === undefined && pageSize === undefined) {
+        project = await Project.findAll({ 
+            include: {
+                model: Projecttag,
+                include: [{ model: Tag, where: { tagTitle: tag }, required: true }],
+                required: true
+            },
+            where: { state: state } });
+    } else {
+        response.status(400).json({ error: "invalid query" });
+        return;
+    }
+    return project;
+}
+
+export const getList = async (request: Request, response: Response) => {
+    let project;
+    if (request.query.state === undefined)
         project = await Project.findAll();
     else if (request.query.state === 'recruiting') {
-        if (request.query.page !== undefined && request.query.pageSize !== undefined) {
-            limit = Number( request.query.pageSize );
-            offset = ( Number( request.query.page ) - 1 ) * limit;
-            project = await Project.findAll({
-                where: { state: 'recruiting' },
-                offset: offset,
-                limit: limit
-            });
-        } else if (request.query.page === undefined && request.query.pageSize === undefined) {
-            project = await Project.findAll({ where: { state: 'recruiting' } });
-        } else {
-            response.status(400).json({ error: "invalid query" });
+        project = await pagination(request, response, 'recruiting');
+        if (!project)
             return;
-        }
-    }
-    else if (request.query.state === 'proceeding') {
-        if (request.query.page !== undefined && request.query.pageSize !== undefined) {
-            limit = Number( request.query.pageSize );
-            offset = ( Number( request.query.page ) - 1 ) * limit;
-            project = await Project.findAll({
-                where: { state: 'proceeding' },
-                offset: offset,
-                limit: limit
-            })
-        } else if (request.query.page === undefined && request.query.pageSize === undefined) {
-            project = await Project.findAll({ where: { state: 'proceeding' } });
-        } else {
-            response.status(400).json({ error: "invalid query" });
+    } else if (request.query.state === 'proceeding') {
+        project = await pagination(request, response, 'proceeding');
+        if (!project)
             return;
-        }
-    }
-    else if (request.query.state === 'completed') {
-        if (request.query.page !== undefined && request.query.pageSize !== undefined) {
-            limit = Number( request.query.pageSize );
-            offset = ( Number( request.query.page ) - 1 ) * limit;
-            project = await Project.findAll({
-                where: { state: 'completed' },
-                offset: offset,
-                limit: limit
-            })
-        } else if (request.query.page === undefined && request.query.pageSize === undefined) {
-            project = await Project.findAll({ where: { state: 'completed' } });
-        } else {
-            response.status(400).json({ error: "invalid query" });
+    } else if (request.query.state === 'completed') {
+        project = await pagination(request, response, 'completed');
+        if (!project)
             return;
-        }
-    }
-    else {
+    } else {
         response.status(400).json({ error: "invalid query" });
         return;
     }


### PR DESCRIPTION
## 요청 url을 변경하였습니다.
기존 : `http://localhost:5000/project/list`
변경 : `http://localhost:5000/project`

## 각 project마다 복수 개의 tag를 부여하고, tag를 활용한 filter 기능을 추가하였습니다.
- 두 개의 테이블이 추가되었습니다. 각 테이블의 column은 다음과 같습니다.
projecttag : projectId (FK), tagId (FK)
tag : tagTitle
(FK : ForeignKey)

- tag 테이블은 이름 그대로 tag 데이터를 모아놓은 테이블입니다.
- projecttag 테이블은 project 테이블과 tag 테이블과의 관계를 나타내는 테이블 입니다.
(Ex. `projecttag` 테이블의 값이 projectId = 1, tagId = 1 이고, `project` table id = 1이 **42DoProject**, `tag` table id = 1이 **react**일 때, 42DoProject에 react태그가 부여되었음을 의미)

- projecttag의 FK column인 projectId는 project table의 Id를 나타내고, tagId는 tag table의 Id를 나타냅니다.
(project-projecttag : 일대다관계, projecttag-tag : 다대일관계)

## project API 명세
- url : `http://localhost:5000/project`
- request
1. state : string, 프로젝트의 상태(`recruiting`, `proceeding`, `completed`)
2. page : number, 페이지
3. pageSize : number, 페이지당 카드 갯수
4. **tag : string[], 기술스택을 가리키는 tag**

- tag 테이블과 projecttag 테이블도 역시 project 테이블과 마찬가지로 임의의 데이터를 직접 넣어주셔야 합니다.
(https://velog.io/@du0928/42DoProject-개발일지 링크에 작성되어 있는 sql을 복붙하시면 쉽게 데이터 입력 가능)

- 요청은 querystring으로 보내주시면 됩니다.
(Ex : `http://localhost:5000/project?state=completed&page=1&pageSize=3&tag=react&tag=express`)