### PR TITLE
feat: #107 #108 #109 CURD project list, content, comments

### DIFF
--- a/back/src/models/index.ts
+++ b/back/src/models/index.ts
@@ -30,10 +30,14 @@ export const mongoose = async () => {
 };
 
 export const initModel = async () => {
-  if (process.env.TAG_LIST === undefined || Tag !== null) {
+  const tagModel = await Tag.findAll();
+  if (process.env.TAG_LIST === undefined) {
     return;
   }
-  let tagList = process.env.TAG_LIST.split(';');
+  if (tagModel.length !== 0) {
+    return;
+  }
+  const tagList = process.env.TAG_LIST.split(';');
   tagList.forEach(async (element) => {
     await Tag.create({
       tagTitle: element

--- a/back/src/routes/project/project.controller.ts
+++ b/back/src/routes/project/project.controller.ts
@@ -28,6 +28,14 @@ router.post("/", (request: Request, response: Response) => {
   projectService.postList(request, response);
 });
 
+router.put("/", (request: Request, response: Response) => {
+  projectService.updateList(request, response);
+});
+
+router.put("/tag", (request: Request, response: Response) => {
+  projectService.updateTag(request, response);
+});
+
 router.delete("/", (request: Request, response: Response) => {
   projectService.deleteList(request, response);
 });
@@ -38,6 +46,18 @@ router.get("/content", (request: Request, response: Response) => {
 
 router.get("/comments", (request: Request, response: Response) => {
   projectService.getComments(request, response);
+});
+
+router.post("/comments", (request: Request, response: Response) => {
+  projectService.postComments(request, response);
+});
+
+router.put("/comments", (request: Request, response: Response) => {
+  projectService.updateComments(request, response);
+});
+
+router.delete("/comments", (request: Request, response: Response) => {
+  projectService.deleteComments(request, response);
 });
 
 export default router;


### PR DESCRIPTION
## Tag filter 기능 오류를 보완
## state 값이 없을 때의 pagination 기능 적용
## project API에 다음의 기능이 추가되었습니다.
- query 요청은 querystring으로 보내주시면 됩니다.
(Ex : `http://localhost:5000/project?projectId=1`)
- body 요청은 request.body를 통해 json 형태로 보내주시면 됩니다.
(Ex. `{"title":"42DoProject", "totalMember":"5", "currentMember":"5", "state":"proceeding", "tag":["react", "express"], "content":"hello world!"}`)

### POST
#### post 프로젝트 list
- url : `http://localhost:5000/project`
- request (body)
1. title : string, 프로젝트 제목
2. totalMember : number, 총 팀원 수
3. currentMember : number, 현재 팀원 수
4. state : string, 프로젝트 상태 ('recruiting', 'proceeding', 'completed')
5. tag : string[], 프로젝트 기술 태그
6. content : string, 프로젝트 본문

#### post comment(댓글)
- url : `http://localhost:5000/project/comments`
- request (body)
1. comment : string, 댓글
2. contentId : number, content 테이블의 idx 번호
3. profileId : number, profile 테이블의 idx 번호

### UPDATE
#### update 프로젝트 list
- url : `http://localhost:5000/project`
- request (query)
1. projectId : number, project 테이블의 idx 번호
- request (body)
1. title : string, 프로젝트 제목
2. totalMember : number, 총 팀원 수
3. currentMember : number, 현재 팀원 수
4. state : string, 프로젝트 상태 ('recruiting', 'proceeding', 'completed')
5. content : string, 프로젝트 본문

#### update tag
- url : `http://localhost:5000/project/tag`
- request (query)
1. projectId : number, project 테이블의 idx 번호
- request (body)
1. tag : string[], 프로젝트 기술 태그

#### update comment(댓글)
- url : `http://localhost:5000/project/comments`
- request (query)
1. commentId : number, comments 테이블의 idx 번호
- request (body)
1. comment : string, 댓글

### DELETE
#### delete comment(댓글)
- url : `http://localhost:5000/project/comments`
- request (query)
1. commentId : number, comments 테이블의 idx 번호