### PR TITLE
[back] feat: #141 add completed state

### DIFF
--- a/back/src/routes/project/project.service.ts
+++ b/back/src/routes/project/project.service.ts
@@ -118,8 +118,11 @@ export const getList = async (request: Request, response: Response) => {
 }
 
 export const postList = async (request: Request, response: Response) => {
-    const { title, totalMember, currentMember, startDate, endDate, content, tag, position } = request.body;
-    let state: string = (totalMember - currentMember > 0) ? 'recruiting' : 'proceeding';
+    const { title, totalMember, currentMember, state, startDate, endDate, content, tag, position } = request.body;
+    let inputState: string = (totalMember - currentMember > 0) ? 'recruiting' : 'proceeding';
+    
+    if (state !== undefined)
+        inputState = state;
 
     await Project.create({
     	title: title,
@@ -127,7 +130,7 @@ export const postList = async (request: Request, response: Response) => {
         // filePath: (request.file === undefined ? null : request.file.path),
         totalMember: totalMember,
         currentMember: currentMember,
-        state: state,
+        state: inputState,
         startDate: startDate,
         endDate: endDate,
         like: 0,
@@ -194,18 +197,20 @@ export const postList = async (request: Request, response: Response) => {
 
 export const updateList = async (request: Request, response: Response) => {
     const { projectId } = request.query;
-    const { title, totalMember, currentMember, startDate, endDate, content } = request.body;
-    let state: string = (totalMember - currentMember > 0) ? 'recruiting' : 'proceeding';
+    const { title, totalMember, currentMember, state, startDate, endDate, content } = request.body;
+    let inputState: string = (totalMember - currentMember > 0) ? 'recruiting' : 'proceeding';
 
     if (projectId === undefined) {
         response.status(400).json({ errMessage: 'please input projectId query' });
     }
+    if (state !== undefined)
+        inputState = state;
 
     await Project.update({
         title: title,
         totalMember: totalMember,
         currentMember: currentMember,
-        state: state,
+        state: inputState,
         startDate: startDate,
         endDate: endDate,
         updatedAt: getIsoString(),


### PR DESCRIPTION
- 프로젝트의 endDate 기준으로 completed 상태를 자동으로 설정하려 했으나, 실시간으로 프로젝트를 감시해야 하는 어려움이 있었음
=> 프로젝트 list를 추가하거나 업데이트할 때, state 요청을 추가적으로 받아서 state 요청으로 completed가 들어올 경우, 상태가 completed로 설정되게끔 수정했습니다. 프로젝트 API에 업데이트 하겠습니다.